### PR TITLE
[DNA-151] Fix for BC and >9999-12-31 date values

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,9 +35,11 @@ jobs:
 
       - name: Tests
         env:
+          TAP_POSTGRES_HOST: localhost
           TAP_POSTGRES_PORT: 5432
           TAP_POSTGRES_USER: test_user
           TAP_POSTGRES_PASSWORD: my-secret-passwd
-          TAP_POSTGRES_HOST: localhost
+          TAP_POSTGRES_SECONDARY_HOST: localhost
+          TAP_POSTGRES_SECONDARY_PORT: 5433
           LOGGING_CONF_FILE: ./sample_logging.conf
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ pylint:
 	pylint --rcfile .pylintrc --disable duplicate-code tap_postgres/
 
 start_db:
-	docker-compose up -d --build db
+	docker-compose up -d
 
 test:
 	. ./venv/bin/activate ;\

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ start_db:
 
 test:
 	. ./venv/bin/activate ;\
-	pytest --cov=tap_postgres  --cov-fail-under=65 tests -v
+	pytest --cov=tap_postgres  --cov-fail-under=68 tests -v

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ start_db:
 
 test:
 	. ./venv/bin/activate ;\
-	pytest --cov=tap_postgres  --cov-fail-under=63 tests -v
+	pytest --cov=tap_postgres  --cov-fail-under=65 tests -v

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ start_db:
 
 test:
 	. ./venv/bin/activate ;\
-	pytest --cov=tap_postgres  --cov-fail-under=59 tests -v
+	pytest --cov=tap_postgres  --cov-fail-under=63 tests -v

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ start_db:
 
 test:
 	. ./venv/bin/activate ;\
-	pytest --cov=tap_postgres  --cov-fail-under=68 tests -v
+	pytest --cov=tap_postgres  --cov-fail-under=85 tests -v

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Full list of options in `config.json`:
 | tap_id                              | String  | No         | ID of the pipeline/tap (Default: None) |
 | itersize                            | Integer | No         | Size of PG cursor iterator when doing INCREMENTAL or FULL_TABLE  (Default: 20000) |
 | default_replication_method          | String  | No         | Default replication method to use when no one is provided in the catalog (Values: `LOG_BASED`, `INCREMENTAL` or `FULL_TABLE`)  (Default: None) |
+| use_secondary                       | Boolean | No         | Use a database replica for `INCREMENTAL` and `FULL_TABLE` replication (Default : False) |
+| secondary_host                      | String  | No         | PostgreSQL Replica host (required if `use_secondary` is `True`) |
+| secondary_port                      | Integer | No         | PostgreSQL Replica port (required if `use_secondary` is `True`) |
 
 
 ### Run the tap in Discovery Mode
@@ -142,7 +145,7 @@ to the tap for the next sync.
     ```
 
     Restart your PostgreSQL service to ensure the changes take effect.
-  
+
     **Note**: For `max_replication_slots` and `max_wal_senders`, we’re defaulting to a value of 5.
     This should be sufficient unless you have a large number of read replicas connected to the master instance.
 
@@ -151,11 +154,11 @@ to the tap for the next sync.
   In PostgreSQL, a logical replication slot represents a stream of database changes that can then be replayed to a
   client in the order they were made on the original server. Each slot streams a sequence of changes from a single
   database.
-  
+
   Login to the master instance as a superuser and using the `wal2json` plugin, create a logical replication slot:
   ```
     SELECT *
-    FROM pg_create_logical_replication_slot('pipelinewise_<database_name>', 'wal2json');  
+    FROM pg_create_logical_replication_slot('pipelinewise_<database_name>', 'wal2json');
   ```
 
   **Note**: Replication slots are specific to a given database in a cluster. If you want to connect multiple
@@ -172,6 +175,8 @@ to the tap for the next sync.
 ```
   export TAP_POSTGRES_HOST=<postgres-host>
   export TAP_POSTGRES_PORT=<postgres-port>
+  export TAP_POSTGRES_SECONDARY_HOST=<postgres-replica-host>
+  export TAP_POSTGRES_SECONDARY_PORT=<postgres-replica-port>
   export TAP_POSTGRES_USER=<postgres-user>
   export TAP_POSTGRES_PASSWORD=<postgres-password>
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,31 @@
 version: "3.3"
 
 services:
-  db:
-    image: "debezium/postgres:12-alpine"
-    container_name: ""
+  db_primary:
+    image: "docker.io/bitnami/postgresql:12"
+    container_name: "primary"
     ports:
       - "5432:5432"
     environment:
+      - POSTGRESQL_REPLICATION_MODE=master
+      - POSTGRESQL_REPLICATION_USER=repl_user
+      - POSTGRESQL_REPLICATION_PASSWORD=repl_password
       - POSTGRES_USER=test_user
       - POSTGRES_PASSWORD=my-secret-passwd
-      - POSTGRES_DB=tap_postgres_test
-    command: -c "wal_level=logical" -c "max_replication_slots=5" -c "max_wal_senders=5"
+      - POSTGRESQL_POSTGRES_PASSWORD=my-secret-passwd
+      - POSTGRESQL_DATABASE=tap_postgres_test
+      - ALLOW_EMPTY_PASSWORD=yes
+  db_replica:
+    image: "docker.io/bitnami/postgresql:12"
+    container_name: replica
+    ports:
+      - "5433:5432"
+    depends_on:
+      - db_primary
+    environment:
+      - POSTGRESQL_REPLICATION_MODE=slave
+      - POSTGRESQL_REPLICATION_USER=repl_user
+      - POSTGRESQL_REPLICATION_PASSWORD=repl_password
+      - POSTGRESQL_MASTER_HOST=db_primary
+      - POSTGRESQL_MASTER_PORT_NUMBER=5432
+      - ALLOW_EMPTY_PASSWORD=yes

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='pipelinewise-tap-postgres',
       ],
       extras_require={
           "test": [
-              'pytest==6.2.5',
+              'pytest==7.0.1',
               'pylint==2.12.*',
               'pytest-cov==3.0.0'
           ]

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -405,8 +405,21 @@ def main_impl():
         'debug_lsn': args.config.get('debug_lsn') == 'true',
         'max_run_seconds': args.config.get('max_run_seconds', 43200),
         'break_at_end_lsn': args.config.get('break_at_end_lsn', True),
-        'logical_poll_total_seconds': float(args.config.get('logical_poll_total_seconds', 0))
+        'logical_poll_total_seconds': float(args.config.get('logical_poll_total_seconds', 0)),
+        'use_secondary': args.config.get('use_secondary', False),
     }
+
+    if conn_config['use_secondary']:
+        try:
+            conn_config.update({
+                # Host and Port are mandatory.
+                'secondary_host': args.config['secondary_host'],
+                'secondary_port': args.config['secondary_port'],
+            })
+        except KeyError as exc:
+            raise ValueError(
+                "When 'use_secondary' enabled 'secondary_host' and 'secondary_port' must be defined."
+            ) from exc
 
     if args.config.get('ssl') == 'true':
         conn_config['sslmode'] = 'require'

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -6,7 +6,6 @@ import psycopg2.extras
 import psycopg2.extensions
 import singer
 import singer.schema
-import signal
 
 from singer import utils, metadata, get_bookmark
 from singer.catalog import Catalog
@@ -21,20 +20,6 @@ from tap_postgres.discovery_utils import discover_db
 from tap_postgres.stream_utils import (
     dump_catalog, clear_state_on_replication_change,
     is_selected_via_metadata, refresh_streams_schema, any_logical_streams)
-
-
-psycopg2.extensions.set_wait_callback(psycopg2.extras.wait_select)
-
-
-def handle_signal(sig=None, frame=None):
-    """
-    signal handler for sigterms
-    raise sigint because that's how psycopg2 aborts running queries
-    """
-    raise KeyboardInterrupt("RECEIVED SIGTERM. RAISING SIGINT TO ABORT POSTGRES QUERY")
-
-
-signal.signal(signal.SIGTERM, handle_signal)
 
 LOGGER = singer.get_logger('tap_postgres')
 

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -6,6 +6,7 @@ import psycopg2.extras
 import psycopg2.extensions
 import singer
 import singer.schema
+import signal
 
 from singer import utils, metadata, get_bookmark
 from singer.catalog import Catalog
@@ -20,6 +21,20 @@ from tap_postgres.discovery_utils import discover_db
 from tap_postgres.stream_utils import (
     dump_catalog, clear_state_on_replication_change,
     is_selected_via_metadata, refresh_streams_schema, any_logical_streams)
+
+
+psycopg2.extensions.set_wait_callback(psycopg2.extras.wait_select)
+
+
+def handle_signal(sig=None, frame=None):
+    """
+    signal handler for sigterms
+    raise sigint because that's how psycopg2 aborts running queries
+    """
+    raise KeyboardInterrupt("RECEIVED SIGTERM. RAISING SIGINT TO ABORT POSTGRES QUERY")
+
+
+signal.signal(signal.SIGTERM, handle_signal)
 
 LOGGER = singer.get_logger('tap_postgres')
 

--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -71,12 +71,19 @@ def prepare_columns_for_select_sql(c, md_map):
 
     if ('properties', c) in md_map:
         sql_datatype = md_map[('properties', c)]['sql-datatype']
-        if sql_datatype.startswith('timestamp') and not sql_datatype.endswith('[]'):
-            return f'CASE ' \
-                   f'WHEN {column_name} < \'0001-01-01 00:00:00.000\' ' \
-                   f'OR {column_name} > \'9999-12-31 23:59:59.999\' THEN \'9999-12-31 23:59:59.999\' ' \
-                   f'ELSE {column_name} ' \
-                   f'END AS {column_name}'
+        if not sql_datatype.endswith('[]'):
+            if sql_datatype.startswith('timestamp'):
+                return f'CASE ' \
+                       f'WHEN {column_name} < \'0001-01-01 00:00:00.000\' ' \
+                       f'OR {column_name} > \'9999-12-31 23:59:59.999\' THEN \'9999-12-31 23:59:59.999\' ' \
+                       f'ELSE {column_name} ' \
+                       f'END AS {column_name}'
+            elif sql_datatype == 'date':
+                return f'CASE ' \
+                       f'WHEN {column_name} < \'0001-01-01\' ' \
+                       f'OR {column_name} > \'9999-12-31\' THEN \'9999-12-31\' ' \
+                       f'ELSE {column_name} ' \
+                       f'END AS {column_name}'
     return column_name
 
 

--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -36,7 +36,7 @@ def fully_qualified_table_name(schema, table):
     return f'"{canonicalize_identifier(schema)}"."{canonicalize_identifier(table)}"'
 
 
-def open_connection(conn_config, logical_replication=False):
+def open_connection(conn_config, logical_replication=False, prioritize_primary=False):
     cfg = {
         'application_name': 'pipelinewise',
         'host': conn_config['host'],
@@ -46,6 +46,14 @@ def open_connection(conn_config, logical_replication=False):
         'port': conn_config['port'],
         'connect_timeout': 30
     }
+
+    if conn_config['use_secondary'] and not prioritize_primary and not logical_replication:
+        # Try to use replica but fallback to primary if keys are missing. This is the same behavior as
+        # https://github.com/transferwise/pipelinewise/blob/master/pipelinewise/fastsync/commons/tap_postgres.py#L129
+        cfg.update({
+            'host': conn_config.get("secondary_host", conn_config['host']),
+            'port': conn_config.get("secondary_port", conn_config['port']),
+        })
 
     if conn_config.get('sslmode'):
         cfg['sslmode'] = conn_config['sslmode']

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -98,10 +98,8 @@ def fetch_current_lsn(conn_config):
             # Use version specific lsn command
             if version >= 100000:
                 cur.execute("SELECT pg_current_wal_lsn() AS current_lsn")
-            elif version >= 90400:
-                cur.execute("SELECT pg_current_xlog_location() AS current_lsn")
             else:
-                raise Exception('Logical replication not supported before PostgreSQL 9.4')
+                cur.execute("SELECT pg_current_xlog_location() AS current_lsn")
 
             current_lsn = cur.fetchone()[0]
             return lsn_to_int(current_lsn)

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -34,7 +34,7 @@ class UnsupportedPayloadKindError(Exception):
 
 # pylint: disable=invalid-name,missing-function-docstring,too-many-branches,too-many-statements,too-many-arguments
 def get_pg_version(conn_info):
-    with post_db.open_connection(conn_info, False) as conn:
+    with post_db.open_connection(conn_info, False, True) as conn:
         with conn.cursor() as cur:
             cur.execute("SELECT setting::int AS version FROM pg_settings WHERE name='server_version_num'")
             version = cur.fetchone()[0]
@@ -93,7 +93,7 @@ def fetch_current_lsn(conn_config):
     if version < 90400:
         raise Exception('Logical replication not supported before PostgreSQL 9.4')
 
-    with post_db.open_connection(conn_config, False) as conn:
+    with post_db.open_connection(conn_config, False, True) as conn:
         with conn.cursor() as cur:
             # Use version specific lsn command
             if version >= 100000:
@@ -138,7 +138,7 @@ def create_hstore_elem_query(elem):
 
 
 def create_hstore_elem(conn_info, elem):
-    with post_db.open_connection(conn_info) as conn:
+    with post_db.open_connection(conn_info, False, True) as conn:
         with conn.cursor() as cur:
             query = create_hstore_elem_query(elem)
             cur.execute(query)
@@ -151,7 +151,7 @@ def create_array_elem(elem, sql_datatype, conn_info):
     if elem is None:
         return None
 
-    with post_db.open_connection(conn_info) as conn:
+    with post_db.open_connection(conn_info, False, True) as conn:
         with conn.cursor() as cur:
             if sql_datatype == 'bit[]':
                 cast_datatype = 'boolean[]'
@@ -517,7 +517,7 @@ def locate_replication_slot_by_cur(cursor, dbname, tap_id=None):
 
 
 def locate_replication_slot(conn_info):
-    with post_db.open_connection(conn_info, False) as conn:
+    with post_db.open_connection(conn_info, False, True) as conn:
         with conn.cursor() as cur:
             return locate_replication_slot_by_cur(cur, conn_info['dbname'], conn_info['tap_id'])
 
@@ -576,7 +576,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
     version = get_pg_version(conn_info)
 
     # Create replication connection and cursor
-    conn = post_db.open_connection(conn_info, True)
+    conn = post_db.open_connection(conn_info, True, True)
     cur = conn.cursor()
 
     # Set session wal_sender_timeout for PG12 and above

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -111,6 +111,32 @@ class TestDbFunctions(unittest.TestCase):
                                               )
         )
 
+    def test_prepare_columns_for_select_sql_with_date_column(self):
+        self.assertEqual(
+            'CASE WHEN  "my_column"  < \'0001-01-01\' OR '
+            ' "my_column"  > \'9999-12-31\' THEN \'9999-12-31\' '
+            'ELSE  "my_column"  END AS  "my_column" ',
+            db.prepare_columns_for_select_sql('my_column',
+                                              {
+                                                  ('properties', 'my_column'): {
+                                                      'sql-datatype': 'date'
+                                                  }
+                                              }
+                                              )
+        )
+
+    def test_prepare_columns_for_select_sql_with_date_array_column(self):
+        self.assertEqual(
+            ' "my_column" ',
+            db.prepare_columns_for_select_sql('my_column',
+                                              {
+                                                  ('properties', 'my_column'): {
+                                                      'sql-datatype': 'date[]'
+                                                  }
+                                              }
+                                              )
+        )
+
     def test_prepare_columns_for_select_sql_with_not_timestamp_column(self):
         self.assertEqual(
             ' "my_column" ',

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,4 +1,7 @@
+import decimal
 import unittest
+
+import datetime
 
 from tap_postgres import db
 
@@ -38,6 +41,20 @@ class TestDbFunctions(unittest.TestCase):
         self.assertEqual(db.selected_value_to_singer_value_impl(True, 'boolean'), True)
         self.assertEqual(db.selected_value_to_singer_value_impl(0, 'boolean'), False)
         self.assertEqual(db.selected_value_to_singer_value_impl(False, 'boolean'), False)
+
+        self.assertEqual(db.selected_value_to_singer_value_impl({'foo': 'bar'}, 'hstore'), {'foo': 'bar'})
+
+        self.assertEqual(db.selected_value_to_singer_value_impl(3.14, 'foo'), 3.14)
+        self.assertEqual(db.selected_value_to_singer_value_impl(float('nan'), 'foo'), None)
+        self.assertEqual(db.selected_value_to_singer_value_impl(float('inf'), 'foo'), None)
+
+        self.assertEqual(db.selected_value_to_singer_value_impl(decimal.Decimal(7), 'foo'), decimal.Decimal(7))
+        self.assertEqual(db.selected_value_to_singer_value_impl(decimal.Decimal('nan'), 'foo'), None)
+
+        self.assertEqual(db.selected_value_to_singer_value_impl(datetime.date(2022, 11, 11), 'foo'),
+                         '2022-11-11T00:00:00+00:00')
+        self.assertEqual(db.selected_value_to_singer_value_impl(datetime.time(11, 11, 11), 'foo'),
+                         '11:11:11')
 
     def test_prepare_columns_sql(self):
         self.assertEqual(' "my_column" ', db.prepare_columns_sql('my_column'))
@@ -153,3 +170,54 @@ class TestDbFunctions(unittest.TestCase):
             'key1': 'A',
             'key2': [{'kk': 'yo'}, {}]
         }, output)
+
+    def test_fully_qualified_column_name(self):
+        schema = 'foo_schema'
+        table = 'foo_table'
+        column = 'foo_column'
+        expected_output = f'"{schema}"."{table}"."{column}"'
+        actual_output = db.fully_qualified_column_name(schema, table, column)
+        self.assertEqual(expected_output, actual_output)
+
+    def test_numeric_precision_returns_default_value_if_column_numeric_precision_greater_than_max_precision(self):
+        class Column:
+            numeric_precision = db.MAX_PRECISION + 1
+
+        actual_output = db.numeric_precision(Column)
+        self.assertEqual(db.MAX_PRECISION, actual_output)
+
+    def test_numeric_scale_returns_default_value_if_column_numeric_scale_greater_than_max_scale(self):
+        class Column:
+            numeric_scale = db.MAX_SCALE + 1
+
+        actual_output = db.numeric_scale(Column)
+        self.assertEqual(db.MAX_SCALE, actual_output)
+
+    def test_selected_array_to_singer_value_if_elem_not_list(self):
+        elem = 'foo'
+        sql_datatype = 'bit'
+        expected_output = False
+        actual_output = db.selected_array_to_singer_value(elem, sql_datatype)
+        self.assertEqual(expected_output, actual_output)
+
+    def test_selected_array_to_singer_value_if_elem_is_list(self):
+        elem = ['foo_1', 'foo_2']
+        sql_datatype = 'bit'
+        expected_output = [False, False]
+        actual_output = db.selected_array_to_singer_value(elem, sql_datatype)
+        self.assertListEqual(expected_output, actual_output)
+
+    def test_filter_dbs_sql_clause(self):
+        sql = 'foo'
+        filter_dbs = 'bar'
+        expected_output = "foo AND datname in ('bar')"
+        actual_output = db.filter_dbs_sql_clause(sql, filter_dbs)
+        self.assertEqual(expected_output, actual_output)
+
+    def test_filter_schemas_sql_clause(self):
+        sql = 'foo'
+        filter_schemas = 'bar_1, bar_2'
+        expected_output = "foo AND n.nspname in ('bar_1','bar_2')"
+        actual_output = db.filter_schemas_sql_clause(sql, filter_schemas)
+        self.assertEqual(expected_output, actual_output)
+

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -331,7 +331,7 @@ class TestHStoreTable(unittest.TestCase):
        table_spec = {"columns": [{"name" : 'our_pk',          "type" : "hstore", "primary_key" : True },
                                  {"name" : 'our_hstore',      "type" : "hstore" }],
                      "name" : TestHStoreTable.table_name}
-       with get_test_connection() as conn:
+       with get_test_connection(superuser=True) as conn:
            cur = conn.cursor()
            cur.execute(""" SELECT installed_version FROM pg_available_extensions WHERE name = 'hstore' """)
            if cur.fetchone()[0] is None:
@@ -536,7 +536,7 @@ class TestColumnGrants(unittest.TestCase):
     table_name = 'CHICKEN TIMES'
     user = 'tmp_user_for_grant_tests'
     password = 'password'
- 
+
     def setUp(self):
         table_spec = {"columns": [{"name" : "id",                "type" : "integer",  "serial" : True},
                                  {"name" : 'size integer',      "type" : "integer",  "quoted" : True},
@@ -545,7 +545,7 @@ class TestColumnGrants(unittest.TestCase):
                      "name" : TestColumnGrants.table_name}
         ensure_test_table(table_spec)
 
-        with get_test_connection() as conn:
+        with get_test_connection(superuser=True) as conn:
            cur = conn.cursor()
 
            sql = """ DROP USER IF EXISTS {} """.format(self.user, self.password)
@@ -560,8 +560,8 @@ class TestColumnGrants(unittest.TestCase):
            LOGGER.info("running sql: {}".format(sql))
            cur.execute(sql)
 
-           
-           
+
+
 
     def test_catalog(self):
         conn_config = get_test_connection_config()
@@ -587,7 +587,7 @@ class TestColumnGrants(unittest.TestCase):
                           ('properties', 'id'): {'inclusion': 'available',
                                                  'selected-by-default': True,
                                                  'sql-datatype': 'integer'}})
-        
+
         self.assertEqual({'definitions' : BASE_RECURSIVE_SCHEMAS,
                           'type': 'object',
                           'properties': {'id': {'type': ['null', 'integer'],

--- a/tests/test_full_table.py
+++ b/tests/test_full_table.py
@@ -1,0 +1,58 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from tap_postgres.sync_strategies.full_table import sync_view
+
+from tests.utils import MockedConnect
+
+
+class TestFullTable(TestCase):
+    """Test Cases for full_table"""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super(TestFullTable, cls).setUpClass()
+        cls.patcher = patch('psycopg2.connect')
+        mocked_connect = cls.patcher.start()
+        mocked_connect.return_value.__enter__.return_value = MockedConnect()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.patcher.stop()
+
+    def setUp(self) -> None:
+        self.conn_config = {
+            'host': 'foo',
+            'dbname': 'foo_db',
+            'user': 'foo_user',
+            'password': 'foo_pass',
+            'port': 12345,
+            'use_secondary': False
+        }
+
+    def test_sync_view(self):
+        """Test for assuring sync_view works as expected"""
+        stream = {
+            'tap_stream_id': 'foo-bar',
+            'schema': {'properties': {'foo_desired': 'b'}},
+            'stream': 'test',
+            'table_name': 'table_name_value',
+            'metadata': [{
+                'metadata': {'sql-datatype': 'test', 'schema-name': 'schema_name_value'},
+                'breadcrumb': ["properties", "foo_desired"],
+            }]
+        }
+        state = {'bookmarks': {'foo-bar': {'foo': 'bar', 'lsn': 4}}}
+        desired_columns = ['foo', 'bar']
+        md_map = {(): {'schema-name': 'pg_catalog', 'replication-key': 'oid'},
+                  ('properties', 'foo'): {'sql-datatype': 'foo'},
+                  ('properties', 'bar'): {'sql-datatype': 'foo'}}
+
+        mocked_time_value = 1234
+        expected_output_without_version = {
+            'bookmarks': {'foo-bar': {'foo': 'bar', 'lsn': 4, 'version': mocked_time_value * 1000}}
+        }
+        with patch('time.time') as mocked_time:
+            mocked_time.return_value = mocked_time_value
+            actual_output = sync_view(self.conn_config, stream, state, desired_columns, md_map)
+            self.assertEqual(expected_output_without_version, actual_output)

--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -124,7 +124,7 @@ class TestLogicalInterruption:
         mock_connect.assert_called_with(**expected_connection)
         mock_connect.reset_mock()
 
-        self.assertEqual(7, len(CAUGHT_MESSAGES), "Number of Caught Messages")
+        assert 7 == len(CAUGHT_MESSAGES)
 
         assert CAUGHT_MESSAGES[0]['type'] =='SCHEMA'
         assert isinstance(CAUGHT_MESSAGES[1], singer.StateMessage)

--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -1,4 +1,7 @@
-import unittest
+import re
+import psycopg2
+import unittest.mock
+import pytest
 import tap_postgres
 import tap_postgres.sync_strategies.full_table as full_table
 import tap_postgres.sync_strategies.common as pg_common
@@ -45,10 +48,12 @@ def do_not_dump_catalog(catalog):
 tap_postgres.dump_catalog = do_not_dump_catalog
 full_table.UPDATE_BOOKMARK_PERIOD = 1
 
-class LogicalInterruption(unittest.TestCase):
+@pytest.mark.parametrize('use_secondary', [False, True])
+@unittest.mock.patch('psycopg2.connect', wraps=psycopg2.connect)
+class TestLogicalInterruption:
     maxDiff = None
 
-    def setUp(self):
+    def setup_method(self):
         table_spec_1 = {"columns": [{"name": "id", "type" : "serial",       "primary_key" : True},
                                     {"name" : 'name', "type": "character varying"},
                                     {"name" : 'colour', "type": "character varying"},
@@ -62,14 +67,28 @@ class LogicalInterruption(unittest.TestCase):
         global CAUGHT_MESSAGES
         CAUGHT_MESSAGES.clear()
 
-    def test_catalog(self):
+    def test_catalog(self, mock_connect, use_secondary):
         singer.write_message = singer_write_message_no_cow
         pg_common.write_schema_message = singer_write_message_ok
 
-        conn_config = get_test_connection_config()
+        conn_config = get_test_connection_config(use_secondary=use_secondary)
         streams = tap_postgres.do_discovery(conn_config)
+
+        # Assert that we connected to the correct database
+        expected_connection = {
+            'application_name': unittest.mock.ANY,
+            'dbname': unittest.mock.ANY,
+            'user': unittest.mock.ANY,
+            'password': unittest.mock.ANY,
+            'connect_timeout':unittest.mock.ANY,
+            'host': conn_config['secondary_host'] if use_secondary else conn_config['host'],
+            'port': conn_config['secondary_port'] if use_secondary else conn_config['port'],
+        }
+        mock_connect.assert_called_once_with(**expected_connection)
+        mock_connect.reset_mock()
+
         cow_stream = [s for s in streams if s['table_name'] == 'COW'][0]
-        self.assertIsNotNone(cow_stream)
+        assert cow_stream is not None
         cow_stream = select_all_of_stream(cow_stream)
         cow_stream = set_replication_method_for_stream(cow_stream, 'LOG_BASED')
 
@@ -90,56 +109,59 @@ class LogicalInterruption(unittest.TestCase):
             insert_record(cur, 'COW', cow_rec)
 
         conn.close()
-           
+
         blew_up_on_cow = False
         state = {}
         #the initial phase of cows logical replication will be a full table.
         #it will sync the first record and then blow up on the 2nd record
         try:
-            tap_postgres.do_sync(get_test_connection_config(), {'streams' : streams}, None, state)
+            tap_postgres.do_sync(get_test_connection_config(use_secondary=use_secondary), {'streams' : streams}, None, state)
         except Exception:
             blew_up_on_cow = True
 
-        self.assertTrue(blew_up_on_cow)
+        assert blew_up_on_cow is True
 
-        self.assertEqual(7, len(CAUGHT_MESSAGES))
+        mock_connect.assert_called_with(**expected_connection)
+        mock_connect.reset_mock()
 
-        self.assertEqual(CAUGHT_MESSAGES[0]['type'], 'SCHEMA')
-        self.assertIsInstance(CAUGHT_MESSAGES[1], singer.StateMessage)
-        self.assertIsNone(CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('xmin'))
-        self.assertIsNotNone(CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('lsn'))
+        assert 7 == len(CAUGHT_MESSAGES)
+
+        assert CAUGHT_MESSAGES[0]['type'] =='SCHEMA'
+        assert isinstance(CAUGHT_MESSAGES[1], singer.StateMessage)
+        assert CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('xmin') is None
+        assert CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('lsn') is not None
         end_lsn = CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('lsn')
 
-        self.assertIsInstance(CAUGHT_MESSAGES[2], singer.ActivateVersionMessage)
+        assert isinstance(CAUGHT_MESSAGES[2], singer.ActivateVersionMessage)
         new_version = CAUGHT_MESSAGES[2].version
 
-        self.assertIsInstance(CAUGHT_MESSAGES[3], singer.RecordMessage)
-        self.assertEqual(CAUGHT_MESSAGES[3].record, {
+        assert isinstance(CAUGHT_MESSAGES[3], singer.RecordMessage)
+        assert CAUGHT_MESSAGES[3].record == {
             'colour': 'blue',
             'id': 1,
             'name': 'betty',
             'timestamp_ntz': '2020-09-01T10:40:59+00:00',
             'timestamp_tz': '2020-08-31T22:50:59+00:00'
-        })
+        }
 
-        self.assertEqual('public-COW', CAUGHT_MESSAGES[3].stream)
+        assert 'public-COW' == CAUGHT_MESSAGES[3].stream
 
-        self.assertIsInstance(CAUGHT_MESSAGES[4], singer.StateMessage)
+        assert isinstance(CAUGHT_MESSAGES[4], singer.StateMessage)
         #xmin is set while we are processing the full table replication
-        self.assertIsNotNone(CAUGHT_MESSAGES[4].value['bookmarks']['public-COW']['xmin'])
-        self.assertEqual(CAUGHT_MESSAGES[4].value['bookmarks']['public-COW']['lsn'], end_lsn)
+        assert CAUGHT_MESSAGES[4].value['bookmarks']['public-COW']['xmin'] is not None
+        assert CAUGHT_MESSAGES[4].value['bookmarks']['public-COW']['lsn'] == end_lsn
 
-        self.assertEqual(CAUGHT_MESSAGES[5].record, {
+        assert CAUGHT_MESSAGES[5].record == {
             'colour': 'brow',
             'id': 2,
             'name': 'smelly',
             'timestamp_ntz': '9999-12-31T23:59:59.999000+00:00',
             'timestamp_tz': '9999-12-31T23:59:59.999000+00:00'
-        })
+        }
 
-        self.assertEqual('public-COW', CAUGHT_MESSAGES[5].stream)
+        assert 'public-COW' == CAUGHT_MESSAGES[5].stream
 
-        self.assertIsInstance(CAUGHT_MESSAGES[6], singer.StateMessage)
+        assert isinstance(CAUGHT_MESSAGES[6], singer.StateMessage)
         last_xmin = CAUGHT_MESSAGES[6].value['bookmarks']['public-COW']['xmin']
         old_state = CAUGHT_MESSAGES[6].value
 
@@ -149,60 +171,65 @@ class LogicalInterruption(unittest.TestCase):
         global COW_RECORD_COUNT
         COW_RECORD_COUNT = 0
         CAUGHT_MESSAGES.clear()
-        tap_postgres.do_sync(get_test_connection_config(), {'streams' : streams}, None, old_state)
+        tap_postgres.do_sync(get_test_connection_config(use_secondary=use_secondary), {'streams' : streams}, None, old_state)
 
-        self.assertEqual(8, len(CAUGHT_MESSAGES))
+        mock_connect.assert_called_with(**expected_connection)
+        mock_connect.reset_mock()
 
-        self.assertEqual(CAUGHT_MESSAGES[0]['type'], 'SCHEMA')
+        assert 8 == len(CAUGHT_MESSAGES)
 
-        self.assertIsInstance(CAUGHT_MESSAGES[1], singer.StateMessage)
-        self.assertEqual(CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('xmin'), last_xmin)
-        self.assertEqual(CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('lsn'), end_lsn)
-        self.assertEqual(CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('version'), new_version)
+        assert CAUGHT_MESSAGES[0]['type'] == 'SCHEMA'
 
-        self.assertIsInstance(CAUGHT_MESSAGES[2], singer.RecordMessage)
-        self.assertEqual(CAUGHT_MESSAGES[2].record, {
+        assert isinstance(CAUGHT_MESSAGES[1], singer.StateMessage)
+        assert CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('xmin') == last_xmin
+        assert CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('lsn') == end_lsn
+        assert CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('version') == new_version
+
+        assert isinstance(CAUGHT_MESSAGES[2], singer.RecordMessage)
+        assert CAUGHT_MESSAGES[2].record == {
             'colour': 'brow',
             'id': 2,
             'name': 'smelly',
             'timestamp_ntz': '9999-12-31T23:59:59.999000+00:00',
             'timestamp_tz': '9999-12-31T23:59:59.999000+00:00'
-        })
+        }
 
-        self.assertEqual('public-COW', CAUGHT_MESSAGES[2].stream)
+        assert 'public-COW' == CAUGHT_MESSAGES[2].stream
 
-        self.assertIsInstance(CAUGHT_MESSAGES[3], singer.StateMessage)
-        self.assertTrue(CAUGHT_MESSAGES[3].value['bookmarks']['public-COW'].get('xmin'),last_xmin)
-        self.assertEqual(CAUGHT_MESSAGES[3].value['bookmarks']['public-COW'].get('lsn'), end_lsn)
-        self.assertEqual(CAUGHT_MESSAGES[3].value['bookmarks']['public-COW'].get('version'), new_version)
+        assert isinstance(CAUGHT_MESSAGES[3], singer.StateMessage)
+        assert CAUGHT_MESSAGES[3].value['bookmarks']['public-COW'].get('xmin'),last_xmin
+        assert CAUGHT_MESSAGES[3].value['bookmarks']['public-COW'].get('lsn') == end_lsn
+        assert CAUGHT_MESSAGES[3].value['bookmarks']['public-COW'].get('version') == new_version
 
-        self.assertIsInstance(CAUGHT_MESSAGES[4], singer.RecordMessage)
-        self.assertEqual(CAUGHT_MESSAGES[4].record, {
+        assert isinstance(CAUGHT_MESSAGES[4], singer.RecordMessage)
+        assert CAUGHT_MESSAGES[4].record == {
             'colour': 'green',
             'id': 3,
             'name': 'pooper',
             'timestamp_ntz': '9999-12-31T23:59:59.999000+00:00',
             'timestamp_tz': '9999-12-31T23:59:59.999000+00:00'
-        })
-        self.assertEqual('public-COW', CAUGHT_MESSAGES[4].stream)
+        }
+        assert 'public-COW' == CAUGHT_MESSAGES[4].stream
 
-        self.assertIsInstance(CAUGHT_MESSAGES[5], singer.StateMessage)
-        self.assertTrue(CAUGHT_MESSAGES[5].value['bookmarks']['public-COW'].get('xmin') > last_xmin)
-        self.assertEqual(CAUGHT_MESSAGES[5].value['bookmarks']['public-COW'].get('lsn'), end_lsn)
-        self.assertEqual(CAUGHT_MESSAGES[5].value['bookmarks']['public-COW'].get('version'), new_version)
+        assert isinstance(CAUGHT_MESSAGES[5], singer.StateMessage)
+        assert CAUGHT_MESSAGES[5].value['bookmarks']['public-COW'].get('xmin') > last_xmin
+        assert CAUGHT_MESSAGES[5].value['bookmarks']['public-COW'].get('lsn') == end_lsn
+        assert CAUGHT_MESSAGES[5].value['bookmarks']['public-COW'].get('version') == new_version
 
 
-        self.assertIsInstance(CAUGHT_MESSAGES[6], singer.ActivateVersionMessage)
-        self.assertEqual(CAUGHT_MESSAGES[6].version, new_version)
+        assert isinstance(CAUGHT_MESSAGES[6], singer.ActivateVersionMessage)
+        assert CAUGHT_MESSAGES[6].version == new_version
 
-        self.assertIsInstance(CAUGHT_MESSAGES[7], singer.StateMessage)
-        self.assertIsNone(CAUGHT_MESSAGES[7].value['bookmarks']['public-COW'].get('xmin'))
-        self.assertEqual(CAUGHT_MESSAGES[7].value['bookmarks']['public-COW'].get('lsn'), end_lsn)
-        self.assertEqual(CAUGHT_MESSAGES[7].value['bookmarks']['public-COW'].get('version'), new_version)
+        assert isinstance(CAUGHT_MESSAGES[7], singer.StateMessage)
+        assert CAUGHT_MESSAGES[7].value['bookmarks']['public-COW'].get('xmin') is None
+        assert CAUGHT_MESSAGES[7].value['bookmarks']['public-COW'].get('lsn') == end_lsn
+        assert CAUGHT_MESSAGES[7].value['bookmarks']['public-COW'].get('version') == new_version
 
-class FullTableInterruption(unittest.TestCase):
+@pytest.mark.parametrize('use_secondary', [False, True])
+@unittest.mock.patch('psycopg2.connect', wraps=psycopg2.connect)
+class TestFullTableInterruption:
     maxDiff = None
-    def setUp(self):
+    def setup_method(self):
         table_spec_1 = {"columns": [{"name": "id", "type" : "serial",       "primary_key" : True},
                                     {"name" : 'name', "type": "character varying"},
                                     {"name" : 'colour', "type": "character varying"}],
@@ -220,25 +247,39 @@ class FullTableInterruption(unittest.TestCase):
         global CAUGHT_MESSAGES
         CAUGHT_MESSAGES.clear()
 
-    def test_catalog(self):
+    def test_catalog(self, mock_connect, use_secondary):
         singer.write_message = singer_write_message_no_cow
         pg_common.write_schema_message = singer_write_message_ok
 
-        conn_config = get_test_connection_config()
+        conn_config = get_test_connection_config(use_secondary=use_secondary)
         streams = tap_postgres.do_discovery(conn_config)
+
+        # Assert that we connected to the correct database
+        expected_connection = {
+            'application_name': unittest.mock.ANY,
+            'dbname': unittest.mock.ANY,
+            'user': unittest.mock.ANY,
+            'password': unittest.mock.ANY,
+            'connect_timeout':unittest.mock.ANY,
+            'host': conn_config['secondary_host'] if use_secondary else conn_config['host'],
+            'port': conn_config['secondary_port'] if use_secondary else conn_config['port'],
+        }
+        mock_connect.assert_called_once_with(**expected_connection)
+        mock_connect.reset_mock()
+
         cow_stream = [s for s in streams if s['table_name'] == 'COW'][0]
-        self.assertIsNotNone(cow_stream)
+        assert cow_stream is not None
         cow_stream = select_all_of_stream(cow_stream)
         cow_stream = set_replication_method_for_stream(cow_stream, 'FULL_TABLE')
 
         chicken_stream = [s for s in streams if s['table_name'] == 'CHICKEN'][0]
-        self.assertIsNotNone(chicken_stream)
+        assert chicken_stream is not None
         chicken_stream = select_all_of_stream(chicken_stream)
         chicken_stream = set_replication_method_for_stream(chicken_stream, 'FULL_TABLE')
 
         conn = get_test_connection()
         conn.autocommit = True
-        
+
         with conn.cursor() as cur:
             cow_rec = {'name': 'betty', 'colour': 'blue'}
             insert_record(cur, 'COW', {'name': 'betty', 'colour': 'blue'})
@@ -256,64 +297,65 @@ class FullTableInterruption(unittest.TestCase):
 
         state = {}
         blew_up_on_cow = False
-        
+
         #this will sync the CHICKEN but then blow up on the COW
         try:
-            tap_postgres.do_sync(get_test_connection_config(), {'streams' : streams}, None, state)
+            tap_postgres.do_sync(get_test_connection_config(use_secondary=use_secondary), {'streams' : streams}, None, state)
         except Exception as ex:
             # LOGGER.exception(ex)
             blew_up_on_cow = True
 
-        self.assertTrue(blew_up_on_cow)
+        assert blew_up_on_cow
+        mock_connect.assert_called_with(**expected_connection)
+        mock_connect.reset_mock()
 
+        assert 14 == len(CAUGHT_MESSAGES)
 
-        self.assertEqual(14, len(CAUGHT_MESSAGES))
+        assert CAUGHT_MESSAGES[0]['type'] == 'SCHEMA'
+        assert isinstance(CAUGHT_MESSAGES[1], singer.StateMessage)
+        assert CAUGHT_MESSAGES[1].value['bookmarks']['public-CHICKEN'].get('xmin') is None
 
-        self.assertEqual(CAUGHT_MESSAGES[0]['type'], 'SCHEMA')
-        self.assertIsInstance(CAUGHT_MESSAGES[1], singer.StateMessage)
-        self.assertIsNone(CAUGHT_MESSAGES[1].value['bookmarks']['public-CHICKEN'].get('xmin'))
-
-        self.assertIsInstance(CAUGHT_MESSAGES[2], singer.ActivateVersionMessage)
+        assert isinstance(CAUGHT_MESSAGES[2], singer.ActivateVersionMessage)
         new_version = CAUGHT_MESSAGES[2].version
 
-        self.assertIsInstance(CAUGHT_MESSAGES[3], singer.RecordMessage)
-        self.assertEqual('public-CHICKEN', CAUGHT_MESSAGES[3].stream)
+        assert isinstance(CAUGHT_MESSAGES[3], singer.RecordMessage)
+        assert 'public-CHICKEN' == CAUGHT_MESSAGES[3].stream
 
-        self.assertIsInstance(CAUGHT_MESSAGES[4], singer.StateMessage)
+        assert isinstance(CAUGHT_MESSAGES[4], singer.StateMessage)
         #xmin is set while we are processing the full table replication
-        self.assertIsNotNone(CAUGHT_MESSAGES[4].value['bookmarks']['public-CHICKEN']['xmin'])
+        assert CAUGHT_MESSAGES[4].value['bookmarks']['public-CHICKEN']['xmin'] is not None
 
-        self.assertIsInstance(CAUGHT_MESSAGES[5], singer.ActivateVersionMessage)
-        self.assertEqual(CAUGHT_MESSAGES[5].version, new_version)
+        assert isinstance(CAUGHT_MESSAGES[5], singer.ActivateVersionMessage)
+        assert CAUGHT_MESSAGES[5].version == new_version
 
-        self.assertIsInstance(CAUGHT_MESSAGES[6], singer.StateMessage)
-        self.assertEqual(None, singer.get_currently_syncing( CAUGHT_MESSAGES[6].value))
+        assert isinstance(CAUGHT_MESSAGES[6], singer.StateMessage)
+        assert None == singer.get_currently_syncing( CAUGHT_MESSAGES[6].value)
         #xmin is cleared at the end of the full table replication
-        self.assertIsNone(CAUGHT_MESSAGES[6].value['bookmarks']['public-CHICKEN']['xmin'])
+        assert CAUGHT_MESSAGES[6].value['bookmarks']['public-CHICKEN']['xmin'] is None
 
 
         #cow messages
-        self.assertEqual(CAUGHT_MESSAGES[7]['type'], 'SCHEMA')
+        assert CAUGHT_MESSAGES[7]['type'] == 'SCHEMA'
 
-        self.assertEqual("public-COW", CAUGHT_MESSAGES[7]['stream'])
-        self.assertIsInstance(CAUGHT_MESSAGES[8], singer.StateMessage)
-        self.assertIsNone(CAUGHT_MESSAGES[8].value['bookmarks']['public-COW'].get('xmin'))
-        self.assertEqual("public-COW", CAUGHT_MESSAGES[8].value['currently_syncing'])
+        assert "public-COW" == CAUGHT_MESSAGES[7]['stream']
+        assert isinstance(CAUGHT_MESSAGES[8], singer.StateMessage)
+        assert CAUGHT_MESSAGES[8].value['bookmarks']['public-COW'].get('xmin') is None
+        assert "public-COW" == CAUGHT_MESSAGES[8].value['currently_syncing']
 
-        self.assertIsInstance(CAUGHT_MESSAGES[9], singer.ActivateVersionMessage)
+        assert isinstance(CAUGHT_MESSAGES[9], singer.ActivateVersionMessage)
         cow_version = CAUGHT_MESSAGES[9].version
-        self.assertIsInstance(CAUGHT_MESSAGES[10], singer.RecordMessage)
+        assert isinstance(CAUGHT_MESSAGES[10], singer.RecordMessage)
 
-        self.assertEqual(CAUGHT_MESSAGES[10].record['name'], 'betty')
-        self.assertEqual('public-COW', CAUGHT_MESSAGES[10].stream)
+        assert CAUGHT_MESSAGES[10].record['name'] == 'betty'
+        assert 'public-COW' == CAUGHT_MESSAGES[10].stream
 
-        self.assertIsInstance(CAUGHT_MESSAGES[11], singer.StateMessage)
+        assert isinstance(CAUGHT_MESSAGES[11], singer.StateMessage)
         #xmin is set while we are processing the full table replication
-        self.assertIsNotNone(CAUGHT_MESSAGES[11].value['bookmarks']['public-COW']['xmin'])
+        assert CAUGHT_MESSAGES[11].value['bookmarks']['public-COW']['xmin'] is not None
 
 
-        self.assertEqual(CAUGHT_MESSAGES[12].record['name'], 'smelly')
-        self.assertEqual('public-COW', CAUGHT_MESSAGES[12].stream)
+        assert CAUGHT_MESSAGES[12].record['name'] == 'smelly'
+        assert 'public-COW' == CAUGHT_MESSAGES[12].stream
         old_state = CAUGHT_MESSAGES[13].value
 
         #run another do_sync
@@ -322,47 +364,44 @@ class FullTableInterruption(unittest.TestCase):
         global COW_RECORD_COUNT
         COW_RECORD_COUNT = 0
 
-        tap_postgres.do_sync(get_test_connection_config(), {'streams' : streams}, None, old_state)
+        tap_postgres.do_sync(get_test_connection_config(use_secondary=use_secondary), {'streams' : streams}, None, old_state)
 
-        self.assertEqual(CAUGHT_MESSAGES[0]['type'], 'SCHEMA')
-        self.assertIsInstance(CAUGHT_MESSAGES[1], singer.StateMessage)
+        mock_connect.assert_called_with(**expected_connection)
+        mock_connect.reset_mock()
+
+        assert CAUGHT_MESSAGES[0]['type'] == 'SCHEMA'
+        assert isinstance(CAUGHT_MESSAGES[1], singer.StateMessage)
 
         # because we were interrupted, we do not switch versions
-        self.assertEqual(CAUGHT_MESSAGES[1].value['bookmarks']['public-COW']['version'], cow_version)
-        self.assertIsNotNone(CAUGHT_MESSAGES[1].value['bookmarks']['public-COW']['xmin'])
-        self.assertEqual("public-COW", singer.get_currently_syncing(CAUGHT_MESSAGES[1].value))
+        assert CAUGHT_MESSAGES[1].value['bookmarks']['public-COW']['version'] == cow_version
+        assert CAUGHT_MESSAGES[1].value['bookmarks']['public-COW']['xmin'] is not None
+        assert "public-COW" == singer.get_currently_syncing(CAUGHT_MESSAGES[1].value)
 
-        self.assertIsInstance(CAUGHT_MESSAGES[2], singer.RecordMessage)
-        self.assertEqual(CAUGHT_MESSAGES[2].record['name'], 'smelly')
-        self.assertEqual('public-COW', CAUGHT_MESSAGES[2].stream)
+        assert isinstance(CAUGHT_MESSAGES[2], singer.RecordMessage)
+        assert CAUGHT_MESSAGES[2].record['name'] == 'smelly'
+        assert 'public-COW' == CAUGHT_MESSAGES[2].stream
 
 
         #after record: activate version, state with no xmin or currently syncing
-        self.assertIsInstance(CAUGHT_MESSAGES[3], singer.StateMessage)
+        assert isinstance(CAUGHT_MESSAGES[3], singer.StateMessage)
         #we still have an xmin for COW because are not yet done with the COW table
-        self.assertIsNotNone(CAUGHT_MESSAGES[3].value['bookmarks']['public-COW']['xmin'])
-        self.assertEqual(singer.get_currently_syncing( CAUGHT_MESSAGES[3].value), 'public-COW')
+        assert CAUGHT_MESSAGES[3].value['bookmarks']['public-COW']['xmin'] is not None
+        assert singer.get_currently_syncing( CAUGHT_MESSAGES[3].value) == 'public-COW'
 
-        self.assertIsInstance(CAUGHT_MESSAGES[4], singer.RecordMessage)
-        self.assertEqual(CAUGHT_MESSAGES[4].record['name'], 'pooper')
-        self.assertEqual('public-COW', CAUGHT_MESSAGES[4].stream)
+        assert isinstance(CAUGHT_MESSAGES[4], singer.RecordMessage)
+        assert CAUGHT_MESSAGES[4].record['name'] == 'pooper'
+        assert 'public-COW' == CAUGHT_MESSAGES[4].stream
 
-        self.assertIsInstance(CAUGHT_MESSAGES[5], singer.StateMessage)
-        self.assertIsNotNone(CAUGHT_MESSAGES[5].value['bookmarks']['public-COW']['xmin'])
-        self.assertEqual(singer.get_currently_syncing( CAUGHT_MESSAGES[5].value), 'public-COW')
+        assert isinstance(CAUGHT_MESSAGES[5], singer.StateMessage)
+        assert CAUGHT_MESSAGES[5].value['bookmarks']['public-COW']['xmin'] is not None
+        assert singer.get_currently_syncing( CAUGHT_MESSAGES[5].value) == 'public-COW'
 
 
         #xmin is cleared because we are finished the full table replication
-        self.assertIsInstance(CAUGHT_MESSAGES[6], singer.ActivateVersionMessage)
-        self.assertEqual(CAUGHT_MESSAGES[6].version, cow_version)
+        assert isinstance(CAUGHT_MESSAGES[6], singer.ActivateVersionMessage)
+        assert CAUGHT_MESSAGES[6].version == cow_version
 
-        self.assertIsInstance(CAUGHT_MESSAGES[7], singer.StateMessage)
-        self.assertIsNone(singer.get_currently_syncing( CAUGHT_MESSAGES[7].value))
-        self.assertIsNone(CAUGHT_MESSAGES[7].value['bookmarks']['public-CHICKEN']['xmin'])
-        self.assertIsNone(singer.get_currently_syncing( CAUGHT_MESSAGES[7].value))
-
-
-if __name__== "__main__":
-    test1 = LogicalInterruption()
-    test1.setUp()
-    test1.test_catalog()
+        assert isinstance(CAUGHT_MESSAGES[7], singer.StateMessage)
+        assert singer.get_currently_syncing( CAUGHT_MESSAGES[7].value) is None
+        assert CAUGHT_MESSAGES[7].value['bookmarks']['public-CHICKEN']['xmin'] is None
+        assert singer.get_currently_syncing( CAUGHT_MESSAGES[7].value) is None

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1,0 +1,98 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+import singer
+
+from tests.utils import MockedConnect
+
+from tap_postgres.sync_strategies import incremental
+
+
+class TestIncremental(TestCase):
+    """Test Cases for Incremental"""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super(TestIncremental, cls).setUpClass()
+        cls.patcher = patch('psycopg2.connect')
+        mocked_connect = cls.patcher.start()
+        mocked_connect.return_value.__enter__.return_value = MockedConnect()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.patcher.stop()
+
+    def setUp(self) -> None:
+        self.conn_config = {
+            'host': 'foo',
+            'dbname': 'foo_db',
+            'user': 'foo_user',
+            'password': 'foo_pass',
+            'port': 12345,
+            'use_secondary': False
+        }
+        self.stream = {'tap_stream_id': 5, 'stream': 'bar', 'table_name': 'pg_tbl'}
+        self.md_map = {
+            (): {'schema-name': 'pg_catalog', 'replication-key': 'foo_key'},
+            ('properties', 'foo_key'): {'sql-datatype': 'foo'},
+            ('properties', 'bar_column'): {'sql-datatype': 'foo'}
+        }
+        self.state = {'bookmarks': {self.stream['tap_stream_id']: {'version': 1, 'replication_key_value': 'foo'}}}
+
+    def test_fetch_max_replication_key(self):
+        """Test if fetch_max_replication works correctly"""
+        expected_max_key = MockedConnect.cursor.fetchone_return_value[0]
+        replication_key = 'foo_key'
+        schema_name = 'foo_schema'
+        table_name = 'foo_table'
+
+        actual_max_key = incremental.fetch_max_replication_key(self.conn_config,
+                                                               replication_key, schema_name, table_name)
+        self.assertEqual(expected_max_key, actual_max_key)
+
+    @patch("psycopg2.extras.register_hstore")
+    def test_sync_table(self, mocked_register_hstore):
+        """Test for sync_table if it works correctly"""
+        desired_columns = ['foo_key']
+        self.state['bookmarks'] = {}
+        expected_state_replication_key_value = MockedConnect.cursor.return_value
+        actual_state = incremental.sync_table(self.conn_config, self.stream, self.state, desired_columns, self.md_map)
+        mocked_register_hstore.assert_called()
+
+        self.assertEqual(expected_state_replication_key_value,
+                         actual_state['bookmarks'][self.stream['tap_stream_id']]['replication_key_value'],
+                         )
+
+    @patch('tap_postgres.sync_strategies.incremental.post_db.hstore_available')
+    @patch('psycopg2.extras.register_hstore')
+    def test_sync_table_if_not_hstore_available(self, _, mocked_hstore_available):
+        """Test for sync_table_ if hstore is unavailable"""
+        desired_columns = ['foo_key']
+        expected_state_replication_key_value = MockedConnect.cursor.return_value
+        mocked_hstore_available.return_value = False
+        actual_state = incremental.sync_table(self.conn_config, self.stream, self.state, desired_columns, self.md_map)
+
+        self.assertEqual(expected_state_replication_key_value,
+                         actual_state['bookmarks'][self.stream['tap_stream_id']]['replication_key_value'])
+
+    @patch("tap_postgres.sync_strategies.incremental.singer.write_message")
+    @patch("psycopg2.extras.register_hstore")
+    def test_sync_table_if_rows_saved_is_a_multiply_of_update_bookmark_period(self,
+                                                                              mocked_register_hstore,
+                                                                              mocked_singer_write):
+        """Test for sync_table if rows_saved is a multiply of UPDATE_BOOKMARK_PERION"""
+        original_update_bookmark_period = incremental.UPDATE_BOOKMARK_PERIOD
+        incremental.UPDATE_BOOKMARK_PERIOD = MockedConnect.cursor.counter_limit - 1
+        desired_columns = ['foo_key']
+        expected_state_replication_key_value = MockedConnect.cursor.return_value
+        actual_state = incremental.sync_table(self.conn_config,
+                                              self.stream,
+                                              self.state,
+                                              desired_columns,
+                                              self.md_map)
+        mocked_register_hstore.assert_called()
+        self.assertEqual(expected_state_replication_key_value,
+                         actual_state['bookmarks'][self.stream['tap_stream_id']]['replication_key_value'],
+                         )
+        incremental.UPDATE_BOOKMARK_PERIOD = original_update_bookmark_period
+        mocked_singer_write.assert_called_with(singer.StateMessage(value=self.state))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,6 +10,47 @@ from singer import get_logger, metadata
 
 LOGGER = get_logger()
 
+
+class MockedConnect:
+    class cursor:
+        return_value = 1234
+        counter_limit = 3
+        fetchone_return_value = [5]
+
+        def __init__(self, *args, **kwargs):
+            self.counter = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args, **kwargs):
+            pass
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            self.counter += 1
+            if self.counter < self.counter_limit:
+                return [self.return_value]
+            raise StopIteration
+
+        def fetchone(self):
+            return self.fetchone_return_value
+
+        def execute(self, *args, **kwargs):
+            pass
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, *args, **kwargs):
+        pass
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+
 def get_test_connection_config(target_db='postgres', use_secondary=False):
     try:
         conn_config = {'host': os.environ['TAP_POSTGRES_HOST'],

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,27 +10,38 @@ from singer import get_logger, metadata
 
 LOGGER = get_logger()
 
-def get_test_connection_config(target_db='postgres'):
-    missing_envs = [x for x in [os.getenv('TAP_POSTGRES_HOST'),
-                                os.getenv('TAP_POSTGRES_USER'),
-                                os.getenv('TAP_POSTGRES_PASSWORD'),
-                                os.getenv('TAP_POSTGRES_PORT')] if x == None]
-    if len(missing_envs) != 0:
-        raise Exception("set TAP_POSTGRES_HOST, TAP_POSTGRES_USER, TAP_POSTGRES_PASSWORD, TAP_POSTGRES_PORT")
+def get_test_connection_config(target_db='postgres', use_secondary=False):
+    try:
+        conn_config = {'host': os.environ['TAP_POSTGRES_HOST'],
+                       'user': os.environ['TAP_POSTGRES_USER'],
+                       'password': os.environ['TAP_POSTGRES_PASSWORD'],
+                       'port': os.environ['TAP_POSTGRES_PORT'],
+                       'dbname': target_db,
+                       'use_secondary': use_secondary,}
+    except KeyError as exc:
+        raise Exception(
+            "set TAP_POSTGRES_HOST, TAP_POSTGRES_USER, TAP_POSTGRES_PASSWORD, TAP_POSTGRES_PORT"
+        ) from exc
 
-    conn_config = {'host': os.environ.get('TAP_POSTGRES_HOST'),
-                   'user': os.environ.get('TAP_POSTGRES_USER'),
-                   'password': os.environ.get('TAP_POSTGRES_PASSWORD'),
-                   'port': os.environ.get('TAP_POSTGRES_PORT'),
-                   'dbname': target_db}
+    if use_secondary:
+        try:
+            conn_config.update({
+                'secondary_host': os.environ['TAP_POSTGRES_SECONDARY_HOST'],
+                'secondary_port': os.environ['TAP_POSTGRES_SECONDARY_PORT'],
+            })
+        except KeyError as exc:
+            raise Exception(
+                "set TAP_POSTGRES_SECONDARY_HOST, TAP_POSTGRES_SECONDARY_PORT"
+            ) from exc
 
     return conn_config
 
-def get_test_connection(target_db='postgres'):
+def get_test_connection(target_db='postgres', superuser=False):
     conn_config = get_test_connection_config(target_db)
+    user = 'postgres' if superuser else conn_config['user']
     conn_string = "host='{}' dbname='{}' user='{}' password='{}' port='{}'".format(conn_config['host'],
                                                                                    conn_config['dbname'],
-                                                                                   conn_config['user'],
+                                                                                   user,
                                                                                    conn_config['password'],
                                                                                    conn_config['port'])
     LOGGER.info("connecting to {}".format(conn_config['host']))


### PR DESCRIPTION
## Problem

Date columns with values that fell outside of Python's `datetime.date.max` and `datetime.date.min` cause meltano pipelines using tap-postgres to error out.

## Proposed changes

Adds the cleaning similar to the timestamp cleaning that's already being done: date values outside the acceptable range are set to the maximum acceptable date. Not ideal, but consistent with how timestamp is done and won't cause problems with NOT NULL date columns.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
